### PR TITLE
Version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karka",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "A simple rule parser",
   "main": "index.js",
   "keywords": [


### PR DESCRIPTION
The only published version of this has jshint in its dependencies list, which is bringing in a vulnerable version of minimatch.

A version bump and publish should fix the issue.
